### PR TITLE
[FIX] _huit_niveaux renvoit parfois des float

### DIFF
--- a/minitel/ImageMinitel.py
+++ b/minitel/ImageMinitel.py
@@ -29,7 +29,7 @@ def _huit_niveaux(niveau):
     # Niveau peut soit être un tuple soit un entier
     # Gère les deux cas en testant l’exception
     try:
-        return niveau * 8 / 256
+        return int(niveau * 8 / 256)
     except TypeError:
         return int(
             round(


### PR DESCRIPTION
Dans certains cas _huit_niveaux renvoyait un float (exemple 255 * 8 / 256)